### PR TITLE
Add validation for matching password for sign up authentication

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -50,6 +50,28 @@ const onSignOut = function (event) {
   .catch(ui.signOutFailure)
 }
 
+const checkPass = function () {
+  const pass1 = document.getElementById('password1')
+  const pass2 = document.getElementById('password2')
+  const message = document.getElementById('confirmMessage')
+
+  const badColor = '#ff6666'
+  const goodColor = '#66cc66'
+  // const goodColor = '#CCE4D5'
+  // const badColor = '#F8C6C0'
+  if (pass1.value === pass2.value) {
+    document.getElementById('chpw-submit').disabled = false
+    pass2.style.backgroundColor = goodColor
+    message.style.color = goodColor
+    message.innerHTML = 'Passwords Match!'
+  } else {
+    document.getElementById('chpw-submit').disabled = true
+    pass2.style.backgroundColor = badColor
+    message.style.color = badColor
+    message.innerHTML = 'Enter matching password!'
+  }
+}
+
 const addHandlers = () => {
   $('#sign-up-form').on('click', onSignUpClick)
   $('#return-to-log-in').on('click', onSignInClick)
@@ -60,5 +82,6 @@ const addHandlers = () => {
 }
 
 module.exports = {
-  addHandlers
+  addHandlers,
+  checkPass
 }

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -10,6 +10,7 @@ const ui = require('./survey/survey-ui')
 
 $(() => {
   setAPIOrigin(location, config)
+  $('#password1, #password2').keyup(authEvents.checkPass)
 
   $('#add-task-modal').on('hidden.bs.modal', function () {
     $(this).find('input,textarea,select').val('').end()
@@ -68,5 +69,4 @@ $(document).ready(function () {
   } else {
     $('#default-content').show()
   }
-
 })

--- a/index.html
+++ b/index.html
@@ -84,8 +84,11 @@
                     <input id="password1" type="password" name="credentials[password]" class="form-control" value="" autocomplete="off" placeholder="Password" required />
                     <label for="name">Password Confirmation</label>
                     <input id="password2" type="password" name="credentials[password_confirmation]" class="form-control" value="" autocomplete="off" placeholder="Confirm Password" required />
+                     <!-- Password Validation (5/18) -->
+                    <span id="confirmMessage" class="confirmMessage"></span>
                    </div>
-                   <button type="submit" name="submit" value="SignUp" class="btn btn-primary btn-block">Submit</button>
+                   <!-- Password Validation (5/18) -->
+                   <button id="chpw-submit" type="submit" name="submit" value="SignUp" class="btn btn-primary btn-block">Submit</button>
                    <div class="modal-footer"></div>
                    <div class="form-subtext">
                      <p>Did you get here on accident ?
@@ -97,7 +100,6 @@
               </div>
         </div>
       </div>
-
 <!-- Change Password Modal-->
 <!-- <div id="add-task-modal" class="container-fluid"> -->
 
@@ -262,7 +264,7 @@
           </div>
         </div>
       <div class="list-group" id ="surveys-content"></div>
-  
+
 </div>
 <!-- End of default-content -->
 


### PR DESCRIPTION
We discovered that new accounts will be created even though password and confirmation-password does not match. This new addition will validate that the passwords match before the user can submit this form. Otherwise, the submit button remain disabled.