### PR TITLE
Fixed typo to the production URL in config.js

### DIFF
--- a/assets/scripts/config.js
+++ b/assets/scripts/config.js
@@ -4,7 +4,7 @@ const config = {
   apiOrigins: {
     development: 'http://localhost:4741',
     // production: 'https://ga-wdi-boston.herokuapp.com'
-    production: 'https:floating-savannah-15725.herokuapp.com'
+    production: 'https://floating-savannah-15725.herokuapp.com'
   }
 }
 


### PR DESCRIPTION
Before:
production: 'https:floating-savannah-15725.herokuapp.com'

After:
production: 'https://floating-savannah-15725.herokuapp.com'