### PR TITLE
Changed event handler for get-survey

### DIFF
--- a/assets/scripts/survey/survey-events.js
+++ b/assets/scripts/survey/survey-events.js
@@ -143,7 +143,7 @@ const addHandlers = () => {
   $('#create-survey').on('submit', onCreateSurvey)
   $('#update-survey').on('submit', onUpdateSurvey)
   $(document).on('click', '.update-survey', updateItem)
-  $(document).on('click', '.get-surveys', onGetSurveys)
+  $(document).on('click', '#get-survey-button', onGetSurveys)
   $(document).on('click', '.remove-survey', deleteItem)
 }
 


### PR DESCRIPTION
get-survey event handler was activated at the div level. As a result, clicking on the white spaces near the button would initiate a GET call. I narrowed the scope to the button.

@conorjennings, @kqngo, @octater, @mattkwondo
