### PR TITLE
Remove inputs upon successfully changed password

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -85,7 +85,7 @@ const changePasswordSuccess = () => {
   $('#ChangePasswordError').hide()
   $('#ChangePasswordSuccess').show().html('Password changed! Close Screen to continue.')
   $('#change-password').trigger('reset')
-  // $('.form-group-pw').hide()
+  $('.form-group-pw').hide()
   // $('.list-group').empty()
 }
 


### PR DESCRIPTION
removing the inputs takes away buttons from users once they have successfully changed their passwords.